### PR TITLE
Add MFA support and improve org handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ const sdk = new MendSdk({
   apiEndpoint: 'https://api.mendfamily.com',
   adminEmail: process.env.MEND_EMAIL!,
   adminPassword: process.env.MEND_PASSWORD!,
-  adminOrgId: Number(process.env.MEND_ORG_ID!)
+  orgId: Number(process.env.MEND_ORG_ID!),
+  mfaCode: process.env.MEND_MFA_CODE
 });
 
 sdk.getUser(12345).then(console.log);
@@ -34,7 +35,8 @@ sdk.getUser(12345).then(console.log);
     apiEndpoint: 'https://api.mendfamily.com',
     adminEmail: 'email@example.com',
     adminPassword: 'secret',
-    adminOrgId: 123
+    orgId: 123,
+    mfaCode: '123456'
   });
   sdk.getUser(12345).then(console.log);
 </script>
@@ -49,6 +51,19 @@ sdk.getUser(12345).then(console.log);
 const rawUser = await sdk.request('GET', '/user/12345');
 ```
 
+### MFA
+
+```ts
+const sdk = new MendSdk({
+  apiEndpoint: 'https://api.mendfamily.com',
+  adminEmail: 'user@example.com',
+  adminPassword: 'secret'
+});
+
+// After the code is sent to the user
+await sdk.submitMfaCode('123456');
+```
+
 ### React component with abort-on-unmount
 
 ```tsx
@@ -59,7 +74,7 @@ const sdk = new MendSdk({
   apiEndpoint  : import.meta.env.VITE_MEND_API,
   adminEmail   : import.meta.env.VITE_MEND_EMAIL,
   adminPassword: import.meta.env.VITE_MEND_PASSWORD,
-  adminOrgId   : Number(import.meta.env.VITE_MEND_ORG_ID)
+  orgId        : Number(import.meta.env.VITE_MEND_ORG_ID)
 });
 
 export function UserCard({ id }: { id: number }) {
@@ -99,7 +114,8 @@ export function UserCard({ id }: { id: number }) {
     apiEndpoint: 'https://api.mendfamily.com',
     adminEmail : 'service@mend.com',
     adminPassword: '•••••',
-    adminOrgId : 123
+    orgId : 123,
+    mfaCode: '123456'
   });
 
   sdk.getUser(12345).then(console.log);
@@ -109,6 +125,7 @@ export function UserCard({ id }: { id: number }) {
 ### Key points
 
 * The first authenticated call automatically logs in and caches the JWT.
+* If only one organization is available the SDK will automatically switch to it.
 * All helpers return **Promises** and accept `AbortSignal` as the last argument.
 * Errors include a `.code` such as `'SDK_CONFIG'`, `'AUTH_MISSING_TOKEN'` or `'HTTP_ERROR'` so you can branch on them.
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4,8 +4,10 @@ export interface MendSdkOptions {
     /** Admin/service account credentials */
     adminEmail: string;
     adminPassword: string;
-    /** Organization ID for the admin/service account */
-    adminOrgId: number;
+    /** Optional organization ID to automatically switch to after login */
+    orgId?: number;
+    /** Optional MFA code for accounts that require it */
+    mfaCode?: string | number;
     /** Minutes before JWT refresh (default 55) */
     tokenTTL?: number;
     /** Optional default headers passed to **every** request (apart from auth headers). */
@@ -24,13 +26,17 @@ export declare class MendSdk {
     private readonly apiEndpoint;
     private readonly adminEmail;
     private readonly adminPassword;
-    private readonly adminOrgId;
+    private readonly orgId?;
+    private readonly mfaCode?;
     private readonly tokenTTL;
     private readonly defaultHeaders;
+    private activeOrgId;
+    private availableOrgs;
     private jwt;
     private jwtExpiresAt;
     constructor(opts: MendSdkOptions);
     private authenticate;
+    private completeLogin;
     private ensureAuth;
     private fetch;
     /**
@@ -48,5 +54,13 @@ export declare class MendSdk {
     listPatients(search: string, page?: number, limit?: number, signal?: AbortSignal): Promise<Json>;
     getAppointment(appointmentId: number, signal?: AbortSignal): Promise<Json>;
     createAppointment(payload: Json, signal?: AbortSignal): Promise<Json>;
+    listOrgs(signal?: AbortSignal): Promise<Json>;
+    /**
+     * Provide a 6‑digit MFA code after calling {@link authenticate}.
+     */
+    submitMfaCode(code: string | number, signal?: AbortSignal): Promise<void>;
+    switchOrg(orgId: number, signal?: AbortSignal): Promise<void>;
+    getProperties(signal?: AbortSignal): Promise<Json>;
+    getProperty(key: string, signal?: AbortSignal): Promise<any>;
 }
 export default MendSdk;

--- a/dist/sdk.cjs.js
+++ b/dist/sdk.cjs.js
@@ -1,7 +1,4 @@
-'use strict';
-
-Object.defineProperty(exports, '__esModule', { value: true });
-
+"use strict";
 // mend-sdk.ts
 // Lightweight Type‑Safe Mend SDK (fetch‑based)
 // ---------------------------------------------------------------------------
@@ -11,21 +8,26 @@ Object.defineProperty(exports, '__esModule', { value: true });
 // • **No runtime React dep** – a React‑specific layer can live in
 //   `@mend/sdk/react` later if you wish.
 // ---------------------------------------------------------------------------
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MendSdk = void 0;
 /* ------------------------------------------------------------------------------------------------
  * Main SDK Class
  * ----------------------------------------------------------------------------------------------*/
 class MendSdk {
     constructor(opts) {
         var _a, _b;
+        this.activeOrgId = null;
+        this.availableOrgs = null;
         this.jwt = null;
         this.jwtExpiresAt = 0; // epoch ms
-        if (!(opts === null || opts === void 0 ? void 0 : opts.apiEndpoint) || !(opts === null || opts === void 0 ? void 0 : opts.adminEmail) || !(opts === null || opts === void 0 ? void 0 : opts.adminPassword) || opts.adminOrgId === void 0) {
-            throw Object.assign(new Error('apiEndpoint, adminEmail, adminPassword, and adminOrgId are required'), { code: 'SDK_CONFIG' });
+        if (!(opts === null || opts === void 0 ? void 0 : opts.apiEndpoint) || !(opts === null || opts === void 0 ? void 0 : opts.adminEmail) || !(opts === null || opts === void 0 ? void 0 : opts.adminPassword)) {
+            throw Object.assign(new Error('apiEndpoint, adminEmail and adminPassword are required'), { code: 'SDK_CONFIG' });
         }
         this.apiEndpoint = opts.apiEndpoint.replace(/\/$/, '');
         this.adminEmail = opts.adminEmail;
         this.adminPassword = opts.adminPassword;
-        this.adminOrgId = opts.adminOrgId;
+        this.orgId = opts.orgId;
+        this.mfaCode = opts.mfaCode;
         this.tokenTTL = (_a = opts.tokenTTL) !== null && _a !== void 0 ? _a : 55;
         this.defaultHeaders = (_b = opts.defaultHeaders) !== null && _b !== void 0 ? _b : {};
     }
@@ -35,15 +37,46 @@ class MendSdk {
     async authenticate() {
         const res = await this.fetch('POST', '/session', {
             email: this.adminEmail,
-            password: this.adminPassword,
-            orgId: this.adminOrgId
+            password: this.adminPassword
         }, {}, /* skipAuth = */ true);
+        const token = res.token;
+        if (token) {
+            await this.completeLogin(res);
+            return;
+        }
+        if (this.mfaCode !== undefined) {
+            await this.submitMfaCode(this.mfaCode);
+            return;
+        }
+        throw Object.assign(new Error('JWT not returned by /session'), { code: 'AUTH_MISSING_TOKEN' });
+    }
+    async completeLogin(res) {
+        var _a, _b;
         const token = res.token;
         if (!token) {
             throw Object.assign(new Error('JWT not returned by /session'), { code: 'AUTH_MISSING_TOKEN' });
         }
         this.jwt = token;
         this.jwtExpiresAt = Date.now() + this.tokenTTL * 60000;
+        const payload = res === null || res === void 0 ? void 0 : res.payload;
+        if (Array.isArray(payload === null || payload === void 0 ? void 0 : payload.orgs)) {
+            this.availableOrgs = payload.orgs;
+        }
+        if (this.orgId !== undefined) {
+            await this.switchOrg(this.orgId);
+        }
+        else {
+            if (!this.availableOrgs) {
+                const orgs = await this.listOrgs();
+                this.availableOrgs = Array.isArray(orgs === null || orgs === void 0 ? void 0 : orgs.payload) ? orgs.payload : (_a = orgs === null || orgs === void 0 ? void 0 : orgs.payload) === null || _a === void 0 ? void 0 : _a.orgs;
+            }
+            if (Array.isArray(this.availableOrgs) && this.availableOrgs.length === 1) {
+                const first = this.availableOrgs[0];
+                const id = (_b = first.id) !== null && _b !== void 0 ? _b : first.orgId;
+                if (id)
+                    await this.switchOrg(id);
+            }
+        }
     }
     async ensureAuth() {
         if (!this.jwt || Date.now() >= this.jwtExpiresAt) {
@@ -121,7 +154,31 @@ class MendSdk {
     createAppointment(payload, signal) {
         return this.request('POST', '/appointment', payload, undefined, signal);
     }
+    listOrgs(signal) {
+        return this.request('GET', '/org', undefined, undefined, signal);
+    }
+    /**
+     * Provide a 6‑digit MFA code after calling {@link authenticate}.
+     */
+    async submitMfaCode(code, signal) {
+        const res = await this.fetch('PUT', '/session/mfa', { mfaCode: code }, {}, true, signal);
+        await this.completeLogin(res);
+    }
+    async switchOrg(orgId, signal) {
+        await this.request('PUT', `/session/org/${orgId}`, {}, undefined, signal);
+        this.activeOrgId = orgId;
+    }
+    async getProperties(signal) {
+        return this.request('GET', '/property', undefined, undefined, signal);
+    }
+    async getProperty(key, signal) {
+        var _a, _b;
+        const props = await this.getProperties(signal);
+        return (_b = (_a = props === null || props === void 0 ? void 0 : props.payload) === null || _a === void 0 ? void 0 : _a.properties) === null || _b === void 0 ? void 0 : _b[key];
+    }
 }
-
 exports.MendSdk = MendSdk;
+/* ------------------------------------------------------------------------------------------------
+ * Default export for CJS interop
+ * ----------------------------------------------------------------------------------------------*/
 exports.default = MendSdk;


### PR DESCRIPTION
## Summary
- rename `adminOrgId` to `orgId`
- add MFA support via `submitMfaCode`
- document new options and behaviour
- rebuild dist files

## Testing
- `npm test`
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b4b42d51483338f006174ce45cd73