### PR TITLE
Mend SDK improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ const sdk = new MendSdk({
 await sdk.submitMfaCode('123456');
 ```
 
+### Error Codes
+
+Errors thrown by the SDK are instances of `MendError` with a `code` field and
+optional `details` from the server response.
+
+| Code | Meaning |
+| --- | --- |
+| `SDK_CONFIG` | Missing required SDK options |
+| `AUTH_MISSING_TOKEN` | Session endpoint did not return a JWT |
+| `AUTH_MFA_REQUIRED` | Login requires a multi-factor authentication code |
+| `AUTH_INVALID_MFA` | Provided MFA code was rejected |
+| `ORG_NOT_FOUND` | Organization does not exist or is inaccessible |
+| `HTTP_ERROR` | Unhandled HTTP error response |
+
+
 ### React component with abort-on-unmount
 
 ```tsx

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -6,12 +6,15 @@ export class MendError extends Error {
   code: string;
   /** HTTP status if applicable */
   status?: number;
+  /** Parsed error body returned by the server */
+  details?: unknown;
 
-  constructor(message: string, code: string, status?: number) {
+  constructor(message: string, code: string, status?: number, details?: unknown) {
     super(message);
     this.name = 'MendError';
     this.code = code;
     this.status = status;
+    this.details = details;
     
     // Ensures proper prototype chain for instanceof checks
     Object.setPrototypeOf(this, MendError.prototype);
@@ -20,11 +23,17 @@ export class MendError extends Error {
 
 // Common error codes
 export const ERROR_CODES = {
+  /** Missing or invalid SDK configuration */
   SDK_CONFIG: 'SDK_CONFIG',
+  /** API did not return a JWT token */
   AUTH_MISSING_TOKEN: 'AUTH_MISSING_TOKEN',
+  /** Login requires multi‑factor authentication */
   AUTH_MFA_REQUIRED: 'AUTH_MFA_REQUIRED',
+  /** Provided MFA code was rejected */
   AUTH_INVALID_MFA: 'AUTH_INVALID_MFA',
+  /** Requested organization does not exist */
   ORG_NOT_FOUND: 'ORG_NOT_FOUND',
+  /** Generic HTTP failure */
   HTTP_ERROR: 'HTTP_ERROR',
 } as const;
 

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -72,14 +72,21 @@ export class HttpClient {
       signal,
     });
 
-    /* Error handling ------------------------------------------------------------------------*/
+    /* Parse body --------------------------------------------------------------*/
+    const text = await resp.text();
+    const parsed = text ? JSON.parse(text) : undefined;
+
+    /* Error handling ----------------------------------------------------------*/
     if (!resp.ok) {
-      throw new MendError(`HTTP ${resp.status} – ${resp.statusText}`, ERROR_CODES.HTTP_ERROR, resp.status);
+      throw new MendError(
+        `HTTP ${resp.status} – ${resp.statusText}`,
+        ERROR_CODES.HTTP_ERROR,
+        resp.status,
+        parsed,
+      );
     }
 
-    /* Some endpoints return empty body (204). Attempt JSON parse only when content exists. */
-    const text = await resp.text();
-    return text ? (JSON.parse(text) as T) : (undefined as unknown as T);
+    return parsed as T;
   }
 }
 

--- a/src/tests/error-handling.test.ts
+++ b/src/tests/error-handling.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import MendSdk, { ERROR_CODES, MendError } from '../lib/index';
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('SDK error mapping', () => {
+  it('maps MFA required responses', async () => {
+    server.use(
+      http.post('https://api.example.com/session', () =>
+        HttpResponse.json({ message: 'MFA required' }, { status: 401 }),
+      ),
+    );
+
+    const sdk = new MendSdk({
+      apiEndpoint: 'https://api.example.com',
+      email: 'user@example.com',
+      password: 'secret',
+      orgId: 1,
+    });
+
+    await expect(sdk.getUser(1)).rejects.toMatchObject({ code: ERROR_CODES.AUTH_MFA_REQUIRED });
+  });
+
+  it('maps invalid MFA code responses', async () => {
+    server.use(
+      http.put('https://api.example.com/session/mfa', () =>
+        HttpResponse.json({ message: 'bad code' }, { status: 401 }),
+      ),
+    );
+
+    const sdk = new MendSdk({
+      apiEndpoint: 'https://api.example.com',
+      email: 'user@example.com',
+      password: 'secret',
+      orgId: 1,
+    });
+    (sdk as any).jwt = 'token';
+
+    await expect(sdk.submitMfaCode('000')).rejects.toMatchObject({ code: ERROR_CODES.AUTH_INVALID_MFA });
+  });
+
+  it('maps org not found responses', async () => {
+    server.use(
+      http.post('https://api.example.com/session', () =>
+        HttpResponse.json({ token: 't', payload: { orgs: [{ id: 1 }] } }),
+      ),
+      http.put('https://api.example.com/session/org/99', () =>
+        HttpResponse.json({ message: 'nope' }, { status: 404 }),
+      ),
+    );
+
+    const sdk = new MendSdk({
+      apiEndpoint: 'https://api.example.com',
+      email: 'user@example.com',
+      password: 'secret',
+      orgId: 1,
+    });
+
+    await expect(sdk.switchOrg(99)).rejects.toMatchObject({ code: ERROR_CODES.ORG_NOT_FOUND });
+  });
+});

--- a/src/tests/http.test.ts
+++ b/src/tests/http.test.ts
@@ -66,14 +66,15 @@ describe('HttpClient', () => {
   
   it('should throw MendError on failed requests', async () => {
     const client = createHttpClient({ apiEndpoint: 'https://api.example.com' });
-    
+
     await expect(client.fetch('GET', '/error')).rejects.toThrow(MendError);
-    
+
     try {
       await client.fetch('GET', '/error');
     } catch (error) {
       expect(error).toBeInstanceOf(MendError);
       expect((error as MendError).status).toBe(400);
+      expect((error as MendError).details).toEqual({ error: 'Test error' });
     }
   });
   


### PR DESCRIPTION
## Summary
- add `details` property to `MendError`
- parse error bodies in `HttpClient`
- surface MFA/org errors with specific codes
- document all error codes in README
- cover new cases in tests

## Testing
- `npm run typecheck` *(fails: Cannot find module 'vitest' etc.)*
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840b0028e9c832b9e4a8f1a3b8def24