### PR TITLE
Mend SDK improve docs and typedoc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,35 @@ try {
 | AUTH_INVALID_MFA | Provided MFA code was rejected |
 | ORG_NOT_FOUND | Organization does not exist or is not accessible |
 | HTTP_ERROR | Other server or network failure |
+
+## API Reference
+
+| Method | Purpose |
+| ------ | ------- |
+| `request(method, path, body?, query?, signal?)` | Low level wrapper used by all helpers |
+| `getOrg(orgId)` | Fetch organization details |
+| `getUser(userId)` | Retrieve a user's details |
+| `searchPatients(query)` | Search patients with filters |
+| `getPatient(id)` | Get a patient record |
+| `getPatientAssessmentScores(id)` | Retrieve a patient's assessment scores |
+| `createPatient(payload, force?)` | Create a new patient |
+| `updatePatient(id, payload, force?)` | Update an existing patient |
+| `deletePatient(id)` | Delete a patient |
+| `getAppointment(id)` | Retrieve an appointment |
+| `createAppointment(payload)` | Create an appointment |
+| `listOrgs()` | List accessible organizations |
+| `submitMfaCode(code)` | Complete MFA authentication |
+| `switchOrg(orgId)` | Change the active organization |
+| `getProperties()` | Fetch all application properties |
+| `getProperty(key)` | Retrieve a single property value |
+| `logout()` | Clear authentication state |
+
+### Troubleshooting
+
+`HTTP_ERROR` covers network failures or unexpected server responses. Check the
+`status` and `details` fields on the thrown `MendError` for clues. Ensure the
+`apiEndpoint` is reachable and credentials are correct. Retrying the request or
+inspecting network traffic with a debugging proxy can help isolate issues.
 ## Patient helpers
 
 
@@ -237,12 +266,25 @@ const all = await sdk.getProperties();
 const timezone = await sdk.getProperty<string>('timezone');
 ```
 
-`getProperty(key)` returns only the value for the given key rather than the full response object.
+`getProperty(key)` returns only the value for the given key rather than the full
+response object. Properties are often used for clinic settings or feature flags.
+
+### Organization management
+
+```ts
+const orgs = await sdk.listOrgs();
+await sdk.switchOrg(456);
+const active = await sdk.getOrg(456);
+```
+
+Use `listOrgs()` to view accessible organizations and `switchOrg()` to change
+which organization subsequent requests operate against.
 
 ## Development
 
 ```bash
 npm run build
+npm run docs
 ```
 
 ## CDN

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "prepublishOnly": "npm run build && npm test",
     "test": "vitest --run --coverage",
     "test:coverage": "vitest --run --coverage",
-    "size": "rollup -c"
+    "size": "rollup -c",
+    "docs": "typedoc"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
@@ -73,6 +74,7 @@
     "tsc-files": "^1.1.4",
     "tslib": "^2.6.2",
     "typescript": "^5.5.2",
-    "vitest": "1.6.1"
+    "vitest": "1.6.1",
+    "typedoc": "^0.25.7"
   }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPoints": ["src/lib/index.ts"],
+  "out": "docs",
+  "name": "Mend SDK",
+  "tsconfig": "tsconfig.json",
+  "includeVersion": true
+}


### PR DESCRIPTION
## Summary
- list all SDK methods in README
- document org management & properties usage
- add troubleshooting tips for `HTTP_ERROR`
- provide typedoc config and docs script

## Testing
- `npm run typecheck` *(fails: Cannot find module)*
- `npm run lint` *(fails: Cannot find parser)*
- `npm test` *(fails: vitest not found)*
- `npm run docs` *(fails: typedoc not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841947199fc832b9373084fabe0a6dc