### PR TITLE
Mend SDK improve type safety

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -59,7 +59,7 @@ export class MendSdk {
   private readonly authMutex = new Mutex();
 
   private activeOrgId: number | null = null;
-  private availableOrgs: Json<any>[] | null = null;
+  private availableOrgs: Json<unknown>[] | null = null;
 
   private jwt: string | null = null;
   private jwtExpiresAt = 0; // epoch ms
@@ -228,7 +228,7 @@ export class MendSdk {
    * // ctrl.abort();
    * ```
    */
-  public async request<T = Json<any>>(
+  public async request<T = Json<unknown>>(
     method: HttpVerb,
     path: string,
     body?: unknown,
@@ -270,7 +270,7 @@ export class MendSdk {
    * @param orgId - Organization ID
    * @param signal - Optional abort signal
    */
-  public async getOrg<T = Json<any>>(orgId: number, signal?: AbortSignal): Promise<T> {
+  public async getOrg<T = Json<unknown>>(orgId: number, signal?: AbortSignal): Promise<T> {
     return this.request<T>('GET', `/org/${orgId}`, undefined, undefined, signal);
   }
 
@@ -280,7 +280,7 @@ export class MendSdk {
    * @param userId - User ID
    * @param signal - Optional abort signal
    */
-  public async getUser<T = Json<any>>(userId: number, signal?: AbortSignal): Promise<T> {
+  public async getUser<T = Json<unknown>>(userId: number, signal?: AbortSignal): Promise<T> {
     return this.request<T>('GET', `/user/${userId}`, undefined, undefined, signal);
   }
 
@@ -290,7 +290,7 @@ export class MendSdk {
    * @param query - Search filters and paging options
    * @param signal - Optional abort signal
    */
-  public async searchPatients<T = Json<any>>(
+  public async searchPatients<T = Json<unknown>>(
     query: QueryParams = {},
     signal?: AbortSignal,
   ): Promise<T> {
@@ -303,7 +303,7 @@ export class MendSdk {
    * @param id - Patient ID
    * @param signal - Optional abort signal
    */
-  public async getPatient<T = Json<any>>(id: number, signal?: AbortSignal): Promise<T> {
+  public async getPatient<T = Json<unknown>>(id: number, signal?: AbortSignal): Promise<T> {
     return this.request<T>('GET', `/patient/${id}`, undefined, undefined, signal);
   }
 
@@ -313,7 +313,7 @@ export class MendSdk {
    * @param id - Patient ID
    * @param signal - Optional abort signal
    */
-  public async getPatientAssessmentScores<T = Json<any>>(id: number, signal?: AbortSignal): Promise<T> {
+  public async getPatientAssessmentScores<T = Json<unknown>>(id: number, signal?: AbortSignal): Promise<T> {
     return this.request<T>('GET', `/patient/${id}/assessment-scores`, undefined, undefined, signal);
   }
 
@@ -324,7 +324,7 @@ export class MendSdk {
    * @param force - Bypass age or validation checks
    * @param signal - Optional abort signal
    */
-  public async createPatient<T = Json<any>>(payload: Json<any>, force = false, signal?: AbortSignal): Promise<T> {
+  public async createPatient<T = Json<unknown>>(payload: Json<unknown>, force = false, signal?: AbortSignal): Promise<T> {
     const path = force ? '/patient/force' : '/patient';
     return this.request<T>('POST', path, payload, undefined, signal);
   }
@@ -337,7 +337,7 @@ export class MendSdk {
    * @param force - Ignore update limits
    * @param signal - Optional abort signal
    */
-  public async updatePatient<T = Json<any>>(id: number, payload: Json<any>, force = false, signal?: AbortSignal): Promise<T> {
+  public async updatePatient<T = Json<unknown>>(id: number, payload: Json<unknown>, force = false, signal?: AbortSignal): Promise<T> {
     const path = force ? `/patient/${id}/force` : `/patient/${id}`;
     return this.request<T>('PUT', path, payload, undefined, signal);
   }
@@ -348,7 +348,7 @@ export class MendSdk {
    * @param id - Patient ID
    * @param signal - Optional abort signal
    */
-  public async deletePatient<T = Json<any>>(id: number, signal?: AbortSignal): Promise<T> {
+  public async deletePatient<T = Json<unknown>>(id: number, signal?: AbortSignal): Promise<T> {
     return this.request<T>('DELETE', `/patient/${id}`, undefined, undefined, signal);
   }
 
@@ -358,7 +358,7 @@ export class MendSdk {
    * @param appointmentId - Appointment ID
    * @param signal - Optional abort signal
    */
-  public async getAppointment<T = Json<any>>(appointmentId: number, signal?: AbortSignal): Promise<T> {
+  public async getAppointment<T = Json<unknown>>(appointmentId: number, signal?: AbortSignal): Promise<T> {
     return this.request<T>('GET', `/appointment/${appointmentId}`, undefined, undefined, signal);
   }
 
@@ -368,7 +368,7 @@ export class MendSdk {
    * @param payload - Appointment details
    * @param signal - Optional abort signal
    */
-  public async createAppointment<T = Json<any>>(payload: Json<any>, signal?: AbortSignal): Promise<T> {
+  public async createAppointment<T = Json<unknown>>(payload: Json<unknown>, signal?: AbortSignal): Promise<T> {
     return this.request<T>('POST', '/appointment', payload, undefined, signal);
   }
 
@@ -388,7 +388,7 @@ export class MendSdk {
     // This bypasses ensureAuth, but still needs the current token if available
     const authHeaders = this.buildAuthHeaders();
     
-    const res = await this.httpClient.fetch<Json<any>>(
+    const res = await this.httpClient.fetch<Json<unknown>>(
       'PUT',
       '/session/mfa',
       { mfaCode: code },
@@ -409,7 +409,7 @@ export class MendSdk {
    */
   public async switchOrg(orgId: number, signal?: AbortSignal): Promise<void> {
     try {
-      await this.request<Json<any>>('PUT', `/session/org/${orgId}`, {}, undefined, signal);
+      await this.request<Json<unknown>>('PUT', `/session/org/${orgId}`, {}, undefined, signal);
       this.activeOrgId = orgId;
     } catch (err) {
       if (err instanceof MendError && err.status === 404) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,36 +1,36 @@
 export interface Org {
-  id: number;
+  readonly id: number;
   /** Some endpoints return orgId instead of id */
-  orgId?: number;
-  name?: string;
-  [key: string]: any;
+  readonly orgId?: number;
+  readonly name?: string;
+  readonly [key: string]: unknown;
 }
 
 export interface User {
-  id: number;
-  [key: string]: any;
+  readonly id: number;
+  readonly [key: string]: unknown;
 }
 
 export interface Patient {
-  id: number;
-  [key: string]: any;
+  readonly id: number;
+  readonly [key: string]: unknown;
 }
 
 export interface AuthResponse {
-  token: string;
-  payload?: {
-    orgs?: Org[];
+  readonly token: string;
+  readonly payload?: {
+    readonly orgs?: Org[];
   };
 }
 
 export interface PropertiesResponse {
-  payload: {
-    properties: Record<string, unknown>;
+  readonly payload: {
+    readonly properties: Record<string, unknown>;
   };
 }
 
 export interface ListOrgsResponse {
-  payload: {
-    orgs: Org[];
+  readonly payload: {
+    readonly orgs: Org[];
   };
 }

--- a/src/tests/coverage.test.ts
+++ b/src/tests/coverage.test.ts
@@ -143,7 +143,7 @@ describe('MendSdk Coverage Tests', () => {
     it('should handle request with body', async () => {
       server.use(
         http.post('https://api.example.com/test', async ({ request }) => {
-          const body = await request.json() as Record<string, any>;
+          const body = await request.json() as Record<string, unknown>;
           if (body?.test === 'value') {
             return HttpResponse.json({ success: true });
           }

--- a/src/tests/utils/test-utils.ts
+++ b/src/tests/utils/test-utils.ts
@@ -171,7 +171,7 @@ export function setupMswServer(additionalHandlers: any[] = []) {
     }),
     
     http.post('*/patient', async ({ request }) => {
-      const body = await request.json().catch(() => ({})) as Record<string, any>;
+      const body = await request.json().catch(() => ({})) as Record<string, unknown>;
       return HttpResponse.json({
         status: 'success',
         patient: { id: 3, ...body }
@@ -180,7 +180,7 @@ export function setupMswServer(additionalHandlers: any[] = []) {
     
     http.put('*/patient/:id', async ({ params, request }) => {
       const { id } = params;
-      const body = await request.json().catch(() => ({})) as Record<string, any>;
+      const body = await request.json().catch(() => ({})) as Record<string, unknown>;
       return HttpResponse.json({
         status: 'success',
         patient: { id: Number(id), ...body }
@@ -263,7 +263,7 @@ export function setupMswServer(additionalHandlers: any[] = []) {
     }),
     
     http.post('*/appointment', async ({ request }) => {
-      const body = await request.json().catch(() => ({})) as Record<string, any>;
+      const body = await request.json().catch(() => ({})) as Record<string, unknown>;
       return HttpResponse.json({
         status: 'success',
         appointment: { id: 1, ...body }

--- a/src/tests/wrappers.test.ts
+++ b/src/tests/wrappers.test.ts
@@ -49,7 +49,7 @@ const server = setupServer(
     return HttpResponse.json({ payload: [] });
   }),
   http.post('https://api.example.com/patient', async ({ request }) => {
-    const body = await request.json() as Record<string, any>;
+    const body = await request.json() as Record<string, unknown>;
     const url = new URL(request.url);
     const forceParam = url.searchParams.get('force');
     
@@ -60,12 +60,12 @@ const server = setupServer(
   }),
   // Force create patient path
   http.post('https://api.example.com/patient/force', async ({ request }) => {
-    const body = await request.json() as Record<string, any>;
+    const body = await request.json() as Record<string, unknown>;
     return HttpResponse.json({ payload: { id: 3, name: body.name, force: true } });
   }),
   http.put('https://api.example.com/patient/:patientId', async ({ request, params }) => {
     const { patientId } = params;
-    const body = await request.json() as Record<string, any>;
+    const body = await request.json() as Record<string, unknown>;
     const url = new URL(request.url);
     const forceParam = url.searchParams.get('force');
     
@@ -77,7 +77,7 @@ const server = setupServer(
   // Force update patient path
   http.put('https://api.example.com/patient/:patientId/force', async ({ request, params }) => {
     const { patientId } = params;
-    const body = await request.json() as Record<string, any>;
+    const body = await request.json() as Record<string, unknown>;
     return HttpResponse.json({ payload: { id: Number(patientId), name: body.name, force: true } });
   }),
   http.delete('https://api.example.com/patient/:patientId', ({ params }) => {
@@ -91,7 +91,7 @@ const server = setupServer(
     return HttpResponse.json({ payload: { id: Number(appointmentId), patient_id: 1, time: '2025-06-01T15:00:00Z' } });
   }),
   http.post('https://api.example.com/appointment', async ({ request }) => {
-    const body = await request.json() as Record<string, any>;
+    const body = await request.json() as Record<string, unknown>;
     return HttpResponse.json({ payload: { id: 2, patient_id: body.patient_id, time: body.time } });
   }),
   
@@ -109,7 +109,7 @@ const server = setupServer(
   
   // Test endpoint for request method tests
   http.post('https://api.example.com/test-endpoint', async ({ request }) => {
-    const body = await request.json() as Record<string, any>;
+    const body = await request.json() as Record<string, unknown>;
     const url = new URL(request.url);
     
     if (body?.test === 'value' && url.searchParams.get('param') === 'value') {


### PR DESCRIPTION
## Summary
- mark API response objects as readonly
- replace use of `any` with `unknown`
- update tests to match new types

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_6841f12f1798832bbe8b7e3bf1ef3570