### PR TITLE
Mend SDK improve type safety and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ await sdk.submitMfaCode('123456');
 
 ```tsx
 import { useEffect, useState } from 'react';
-import MendSdk from '@menddev/sdk';
+import MendSdk, { Json, User } from '@menddev/sdk';
 
 const sdk = new MendSdk({
   apiEndpoint: import.meta.env.VITE_MEND_API,
@@ -82,14 +82,14 @@ const sdk = new MendSdk({
 });
 
 export function UserCard({ id }: { id: number }) {
-  const [user, setUser] = useState<any>();
+  const [user, setUser] = useState<Json<{ payload: { user: User } }> | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const abort = new AbortController();
 
-    sdk
-      .getUser(id, abort.signal)
+  sdk
+      .getUser<Json<{ payload: { user: User } }>>(id, abort.signal)
       .then(setUser)
       .catch((err) => {
         if (err.name !== 'AbortError') setError(err.message);

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -134,8 +134,19 @@ export class HttpClient {
     }
 
     /* Some endpoints return empty body (204). Attempt JSON parse only when content exists. */
-    const text = await resp.text();
-    return text ? (JSON.parse(text) as T) : (undefined as unknown as T);
+    try {
+      const text = await resp.text();
+      if (!text) return undefined as unknown as T;
+      return JSON.parse(text) as T;
+    } catch (err) {
+      throw new MendError(
+        (err as Error).message,
+        ERROR_CODES.HTTP_ERROR,
+        resp.status,
+        undefined,
+        context,
+      );
+    }
   }
 }
 

--- a/src/tests/http.test.ts
+++ b/src/tests/http.test.ts
@@ -48,12 +48,17 @@ const server = setupServer(
   
   // Handler for testing headers
   http.get('https://api.example.com/headers', ({ request }) => {
-    return HttpResponse.json({ 
+    return HttpResponse.json({
       headers: {
         'x-custom-header': request.headers.get('x-custom-header'),
         'content-type': request.headers.get('content-type')
       }
     });
+  }),
+
+  // Handler returning invalid JSON
+  http.get('https://api.example.com/badjson', () => {
+    return new HttpResponse('not-json', { headers: { 'content-type': 'application/json' } });
   }),
   
   // Handler for testing empty responses
@@ -190,5 +195,11 @@ describe('HttpClient', () => {
     }
 
     fetchSpy.mockRestore();
+  });
+
+  it('should wrap JSON parse errors in MendError', async () => {
+    const client = createHttpClient({ apiEndpoint: 'https://api.example.com' });
+
+    await expect(client.fetch('GET', '/badjson')).rejects.toBeInstanceOf(MendError);
   });
 });


### PR DESCRIPTION
## Summary
- show how to type the `user` state in the React example
- handle JSON parse errors in `HttpClient.fetch`
- test error handling on invalid JSON responses

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6842f4973234832bae9776b209635e37